### PR TITLE
Zsh vi mode prompt indicator

### DIFF
--- a/_zsh.d/joemiller.zsh-theme
+++ b/_zsh.d/joemiller.zsh-theme
@@ -5,7 +5,10 @@ if [[ $UID -eq 0 ]]; then USERPROMPT="%{$FG[179]%}root@%{$reset_color%}"; else U
 
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
-PROMPT='$USERPROMPT%{$FG[074]%}%m %{${fg_bold[blue]}%}%{$reset_color%}%{${FG[035]}%}%3~ $(kube_info)$(git_prompt_info)%{${fg_bold[$CARETCOLOR]}%}»%{${reset_color}%} '
+# wrap this in a func so we can call it from zle-keymap-select() when toggling vi modes to redraw
+function set_prompt() {
+    PROMPT='$USERPROMPT%{$FG[074]%}%m %{${fg_bold[blue]}%}%{$reset_color%}%{${FG[035]}%}%3~ $(kube_info)$(git_prompt_info)$(vi_mode) %{${fg_bold[$CARETCOLOR]}%}»%{${reset_color}%} '
+}
 
 RPS1="${return_code}"
 
@@ -52,6 +55,31 @@ function kube_info() {
   echo "${CLUSTER_COLOR}${PREFIX}${cluster_shortname}${NS_COLOR}${namespace}${SUFFIX}%{${reset_color}%} "
 }
 
+# hook into visual indication when switching between vi modes
+# NOTE: the cursor-shape modifier is iterm specific for macOS. other os's and terminals might be able to use $terminfo[...],
+#       see this link for more info: http://unix.stackexchange.com/a/1120
+# Thanks to https://hamberg.no/erlend/posts/2014-03-09-change-vim-cursor-in-iterm.html for iTerm cursor trick
+function vi_mode() {
+  case $KEYMAP in
+    vicmd)
+        [[ "$TERM_PROGRAM" == "iTerm.app" ]] && printf "\033]50;CursorShape=0\x7"
+        echo "%{$fg_bold[yellow]%}[n]%{$reset_color%}"
+        ;;
+    viins|main|*)
+        [[ "$TERM_PROGRAM" == "iTerm.app" ]] && printf "\033]50;CursorShape=1\x7"
+        echo "%{$fg_bold[blue]%}[i]%{$reset_color%}"
+        ;;
+  esac
+}
+
+function zle-line-init zle-keymap-select {
+  zle reset-prompt
+}
+
+zle -N zle-line-init
+zle -N zle-keymap-select
+
+# magic for tmux title bars
 DISABLE_AUTO_TITLE="true"
 precmd() {
   # set hostname:PWD in iterm2 title bar
@@ -65,12 +93,5 @@ precmd() {
   fi
 }
 
-# hook into visual indication when switching between vi modes
-function zle-line-init zle-keymap-select {
-    VIM_PROMPT="%{$fg_bold[yellow]%} [% NORMAL]%  %{$reset_color%}"
-    RPS1="${${KEYMAP/vicmd/$VIM_PROMPT}/(main|viins)/} $EPS1"
-    zle reset-prompt
-}
-
-zle -N zle-line-init
-zle -N zle-keymap-select
+# main(), sorta
+set_prompt

--- a/_zshrc
+++ b/_zshrc
@@ -62,4 +62,8 @@ fpath=(/usr/local/share/zsh/site-functions $fpath)
 # vi mode settings
 bindkey -v
 bindkey '^r' history-incremental-search-backward
+bindkey '^?' backward-delete-char
+bindkey '^h' backward-delete-char
+bindkey '^r' history-incremental-search-backward
+bindkey '^w' backward-kill-word
 export KEYTIMEOUT=1


### PR DESCRIPTION
this adds two visual indicators when toggling between insert-mode and normal-mode in zsh's vi mode:

1. a colored `[i]` or `[n]` text block indication
2. if terminal is `iTerm.app`, toggle the cursor from block to line shape

insert mode:
![image](https://cloud.githubusercontent.com/assets/377603/20974887/7abb3b24-bc52-11e6-8911-55b8a09d6187.png)

normal mode:
![image](https://cloud.githubusercontent.com/assets/377603/20974895/854cc1fc-bc52-11e6-9675-35e09028eee5.png)

I might remove the `[i]` and n blocks and just use the cursor shape.